### PR TITLE
correcao para varios item no mesmo pedido.

### DIFF
--- a/prisma/migrations/20240920022824_correcao_pedidos/migration.sql
+++ b/prisma/migrations/20240920022824_correcao_pedidos/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `productId` on the `Order` table. All the data in the column will be lost.
+  - You are about to drop the column `quantity` on the `Order` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_productId_fkey";
+
+-- AlterTable
+ALTER TABLE "Order" DROP COLUMN "productId",
+DROP COLUMN "quantity";
+
+-- CreateTable
+CREATE TABLE "OrderItem" (
+    "id" SERIAL NOT NULL,
+    "orderId" INTEGER NOT NULL,
+    "productId" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "unitPrice" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,28 +8,36 @@ generator client {
 }
 
 model Product {
-  id          Int     @id @default(autoincrement())
+  id          Int         @id @default(autoincrement())
   name        String
   price       Float
   description String
   stock       Int
-  orders      Order[] @relation("ProductOrders") // Relação com Orders
+  ordersItems OrderItem[] // Relacionamento com os itens de pedido
 }
 
 model Order {
-  id         Int      @id @default(autoincrement())
-  productId  Int
-  product    Product  @relation("ProductOrders", fields: [productId], references: [id])
-  quantity   Int
+  id         Int         @id @default(autoincrement())
   totalPrice Float
   status     String
-  createdAt  DateTime @default(now())
+  createdAt  DateTime    @default(now())
+  items      OrderItem[] // Relacionamento com os itens do pedido
+}
+
+model OrderItem {
+  id        Int     @id @default(autoincrement())
+  orderId   Int
+  order     Order   @relation(fields: [orderId], references: [id])
+  productId Int
+  product   Product @relation(fields: [productId], references: [id])
+  quantity  Int
+  unitPrice Float
 }
 
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique
-  username  String   @unique 
+  username  String   @unique
   password  String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
antes os pedidos so podia ter 1 item. Quando gerava 1 pedido com varios items, geravam pedidos com ID diferentes o que atrapalha o balanço geral no final.

Aplicada correção para quando tiver + de um item no pedido gere o pedido com 1 unico ID mesmo que tenho mais de 1 item no pedido